### PR TITLE
Add check for std::getline eofbit

### DIFF
--- a/src/ilc.cpp
+++ b/src/ilc.cpp
@@ -143,7 +143,7 @@ int main(int argc, char **argv) {
                 std::cout << std::endl;
                 
                 return EXIT_SUCCESS;
-            };
+            }
             
             // TODO: Throwing linker reference error.
             // Trim whitespace off input string.

--- a/src/ilc.cpp
+++ b/src/ilc.cpp
@@ -138,13 +138,13 @@ int main(int argc, char **argv) {
             std::cout << ConsoleColor::coat("<> ", ColorKind::ForegroundGray);
             std::cout.flush();
 
-			// If the EOF bit is on, terminate program.
-			if (std::getline(std::cin, input).eof()) {
-				std::cout << std::endl;
-				
-				return EXIT_SUCCESS;
-			};
-			
+            // If the EOF bit is on, terminate program.
+            if (std::getline(std::cin, input).eof()) {
+                std::cout << std::endl;
+                
+                return EXIT_SUCCESS;
+            };
+            
             // TODO: Throwing linker reference error.
             // Trim whitespace off input string.
 //            input = ionshared::util::trim(input);

--- a/src/ilc.cpp
+++ b/src/ilc.cpp
@@ -137,8 +137,14 @@ int main(int argc, char **argv) {
         while (true) {
             std::cout << ConsoleColor::coat("<> ", ColorKind::ForegroundGray);
             std::cout.flush();
-            std::getline(std::cin, input);
 
+			// If the EOF bit is on, terminate program.
+			if (std::getline(std::cin, input).eof()) {
+				std::cout << std::endl;
+				
+				return EXIT_SUCCESS;
+			};
+			
             // TODO: Throwing linker reference error.
             // Trim whitespace off input string.
 //            input = ionshared::util::trim(input);


### PR DESCRIPTION
This fixes the issue where if you press Ctrl+D on *nix platforms it spams the prompt text:
![the problem](https://i.ronthecookie.me/pdJKmZ8.png)